### PR TITLE
Removed the / of service-worker.js as it breaks reverse proxying

### DIFF
--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -548,7 +548,7 @@ const snapdrop = new Snapdrop();
 
 
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js')
+    navigator.serviceWorker.register('service-worker.js')
         .then(serviceWorker => {
             console.log('Service Worker registered');
             window.serviceWorker = serviceWorker


### PR DESCRIPTION
Without this change, I have this error (snapdrop is hosted on https://xxxx/snapdrop)

![image](https://github.com/user-attachments/assets/84f77ce7-7d69-4f0e-8437-e4d7e0f9e930)
