### PR TITLE
Fix manifest if snapdrop isn't on root path

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -25,7 +25,6 @@
         "type": "image/png"
     }],
     "background_color": "#efefef",
-    "start_url": "/",
     "display": "minimal-ui",
     "theme_color": "#3367d6",
     "share_target": {


### PR DESCRIPTION
Without this, if the user add snapdrop isn't on root pass `http://myserver.local/snapdrop` to the home screen, then when click on the icon, it will go to `http://myserver.local` instead.