### PR TITLE
Supplements the Reverse Proxy configuration instructions for docker deployment.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - ./server/:/home/node/app
     command: ash -c "npm i && node index.js"
+    ports:
+      - "3000:3000"
   nginx:
     build:
       context: ./docker/

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -52,7 +52,21 @@ The site is served on `https://<Your FQDN>:443`.
 ## Deployment Notes
 The client expects the server at http(s)://your.domain/server.
 
-When serving the node server behind a proxy, the `X-Forwarded-For` header has to be set by the proxy. Otherwise, all clients that are served by the proxy will be mutually visible.
+When serving the node server behind a proxy, you need to configure the proxy separately for the node server. For nginx the configuration should look like this:
+``` 
+location ^~ /server {
+    proxy_pass http://127.0.0.1:3000; 
+    proxy_set_header Host $host; 
+    proxy_set_header X-Real-IP $remote_addr; 
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
+    proxy_set_header REMOTE-HOST $remote_addr; 
+    proxy_set_header Upgrade $http_upgrade; 
+    proxy_set_header Connection "upgrade"; 
+    add_header Cache-Control no-cache; 
+}
+```
+
+Tips: the `X-Forwarded-For` header has to be set by the proxy. Otherwise, all clients that are served by the proxy will be mutually visible.
 
 By default, the server listens on port 3000.
 


### PR DESCRIPTION
Supplements the Reverse Proxy configuration instructions for docker deployment.
Modify docker-compose to expose port 3000

When I created reverse proxy for docker, no one told me that I should create a separate reverse proxy rule for node server. I think people should see this in the documentation.