### PR TITLE
fix: Obtain peerid from the cookie.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -197,7 +197,9 @@ class Peer {
         if (request.peerId) {
             this.id = request.peerId;
         } else {
-            this.id = request.headers.cookie.replace('peerid=', '');
+            const parts = request.headers.cookie.split(';').map(part => part.trim());
+            const peerIdPart = parts.find(part => part.startsWith('peerid='));
+            this.id = peerIdPart.replace('peerid=', '');
         }
     }
 


### PR DESCRIPTION
If the page has other cookie operations that result in the cookies being cluttered with additional values, you need to extract the correct value of peerid.